### PR TITLE
Introduce mustache templating for client-side partials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 buck-out
 out
 .idea/libraries
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .buckd
 buck-out
 out
-.idea/libraries
+.idea
 node_modules

--- a/BUCK
+++ b/BUCK
@@ -2,7 +2,7 @@
 genrule(
     name = '_bundle-javascript',
     srcs = glob( [ 'src/main/javascript/**/*' ] ),
-    cmd = 'browserify --debug src/main/javascript/home.js > $OUT',
+    cmd = 'browserify --debug src/main/javascript/home.js -o $OUT',
     out = 'home.js'
 )
 

--- a/BUCK
+++ b/BUCK
@@ -2,7 +2,7 @@
 genrule(
     name = '_bundle-javascript',
     srcs = glob( [ 'src/main/javascript/**/*' ] ),
-    cmd = 'node ./../../../node_modules/.bin/browserify --debug src/main/javascript/home.js -o $OUT',
+    cmd = './../../../node_modules/.bin/browserify --debug src/main/javascript/home.js -o $OUT',
     out = 'home.js'
 )
 

--- a/BUCK
+++ b/BUCK
@@ -2,7 +2,7 @@
 genrule(
     name = '_bundle-javascript',
     srcs = glob( [ 'src/main/javascript/**/*' ] ),
-    cmd = 'nodejs ./../../../node_modules/.bin/browserify --debug src/main/javascript/home.js -o $OUT',
+    cmd = 'node ./../../../node_modules/.bin/browserify --debug src/main/javascript/home.js -o $OUT',
     out = 'home.js'
 )
 

--- a/BUCK
+++ b/BUCK
@@ -2,7 +2,7 @@
 genrule(
     name = '_bundle-javascript',
     srcs = glob( [ 'src/main/javascript/**/*' ] ),
-    cmd = 'browserify --debug src/main/javascript/home.js -o $OUT',
+    cmd = 'nodejs ./../../../node_modules/.bin/browserify --debug src/main/javascript/home.js -o $OUT',
     out = 'home.js'
 )
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Template project for Java 8 web app stack using spark, redis, bootstrap, jade an
 
 1. clone me
 2. install and start redis
-3. run npm install --save
+3. run npm install
 4. clone buck and put buck/bin on your path
 5. buck run :srbb
 6. http://localhost:4567

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Template project for Java 8 web app stack using spark, redis, bootstrap, jade an
 
 1. clone me
 2. install and start redis
-3. install browserify using npm -g browserify
+3. run npm install --save
 4. clone buck and put buck/bin on your path
 5. buck run :srbb
 6. http://localhost:4567

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "template",
     "devDependencies": {
+        "browserify": "8.0.2",
         "browserify-mustache": "0.0.4"
     },
     "browserify": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "template",
+    "devDependencies": {
+        "browserify-mustache": "0.0.4"
+    },
+    "browserify": {
+        "transform": [
+            "browserify-mustache"
+        ]
+    }
+}

--- a/src/main/javascript/home.js
+++ b/src/main/javascript/home.js
@@ -1,3 +1,5 @@
+var welcomeMessage = require('./partials/message.mustache');
+
 $(function() {
-    $('.container').append($('<p>').text('Javascript enabled'));
+    $('#message').html(welcomeMessage());
 });

--- a/src/main/javascript/partials/message.mustache
+++ b/src/main/javascript/partials/message.mustache
@@ -1,0 +1,1 @@
+<p>Javascript is enabled</p>

--- a/src/main/resources/views/home.jade
+++ b/src/main/resources/views/home.jade
@@ -4,3 +4,4 @@ block content
   .home
     h1 Hello
     p Css enabled if this is blue
+  #message


### PR DESCRIPTION
Instead of calling $.append on DOM objects, use mustache templates to build up DOM objects and apply the html produced accordingly.

Mustache templates can be imported into a js file like other local browserify dependencies, and are compiled at bundle time with the browserify-mustache transform.

Created a package.json to bring this dependency in, and also added browserify to this. Allows for the README.MD to be changed so a user just needs to call npm install after downloading the project (avoids including the node_modules directory). The call to browserify in the BUCK file isn't very nice, but wasn't sure how else to do it.
